### PR TITLE
[#2] feat: Typography 추가

### DIFF
--- a/lib/components/Typography/Typography.stories.ts
+++ b/lib/components/Typography/Typography.stories.ts
@@ -1,46 +1,18 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import Typography from ".";
 
-// More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta = {
-  title: "Example/Button",
+  title: "Foundation/Typography",
   component: Typography,
-  parameters: {
-    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/react/configure/story-layout
-    layout: "centered",
-  },
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/react/writing-docs/autodocs
   tags: ["autodocs"],
-  // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
 } satisfies Meta<typeof Typography>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
 export const Primary: Story = {
   args: {
     text: "Hello World",
     variant: "caption2",
   },
 };
-
-// export const Secondary: Story = {
-//   args: {
-//     label: "Button",
-//   },
-// };
-
-// export const Large: Story = {
-//   args: {
-//     size: "large",
-//     label: "Button",
-//   },
-// };
-
-// export const Small: Story = {
-//   args: {
-//     size: "small",
-//     label: "Button",
-//   },
-// };

--- a/lib/components/Typography/index.tsx
+++ b/lib/components/Typography/index.tsx
@@ -1,22 +1,22 @@
 import styles from "./styles.module.css";
 
-const variants = [
-  "caption2",
-  "caption2strong",
-  "caption1",
-  "caption1strong",
-  "body1",
-  "body1strong",
-  "body2",
-  "body2strong",
-  "subtitle1",
-  "title3",
-  "title2",
-  "title1",
-  "largetitle",
-] as const;
+const variants = {
+  caption2: "caption2",
+  caption2strong: "caption2strong",
+  caption1: "caption1",
+  caption1strong: "caption1strong",
+  body1: "body1",
+  body1strong: "body1strong",
+  body2: "body2",
+  body2strong: "body2strong",
+  subtitle1: "subtitle1",
+  title3: "title3",
+  title2: "title2",
+  title1: "title1",
+  largetitle: "largetitle",
+};
 
-type TypographyVariant = (typeof variants)[number];
+type TypographyVariant = keyof typeof variants;
 
 interface TypographyProps {
   text: string;

--- a/lib/components/Typography/index.tsx
+++ b/lib/components/Typography/index.tsx
@@ -1,0 +1,30 @@
+import styles from "./styles.module.css";
+
+const variants = [
+  "caption2",
+  "caption2strong",
+  "caption1",
+  "caption1strong",
+  "body1",
+  "body1strong",
+  "body2",
+  "body2strong",
+  "subtitle1",
+  "title3",
+  "title2",
+  "title1",
+  "largetitle",
+] as const;
+
+type TypographyVariant = (typeof variants)[number];
+
+interface TypographyProps {
+  text: string;
+  variant: TypographyVariant;
+}
+
+function Typography({ text, variant }: TypographyProps) {
+  return <span className={`${styles[variant]}`}>{text}</span>;
+}
+
+export default Typography;

--- a/lib/components/Typography/styles.module.css
+++ b/lib/components/Typography/styles.module.css
@@ -1,0 +1,101 @@
+@value regular: 400;
+@value bold: 500;
+@value semibold: 600;
+
+@value size100: 10px;
+@value size200: 12px;
+@value size300: 14px;
+@value size400: 16px;
+@value size500: 20px;
+@value size600: 24px;
+@value size700: 28px;
+@value size800: 32px;
+@value size900: 40px;
+
+@value lineHeight100: 14px;
+@value lineHeight200: 16px;
+@value lineHeight300: 20px;
+@value lineHeight400: 22px;
+@value lineHeight500: 26px;
+@value lineHeight600: 32px;
+@value lineHeight700: 36px;
+@value lineHeight800: 40px;
+@value lineHeight900: 52px;
+
+.caption2 {
+  font-weight: regular;
+  font-size: size100;
+  list-style: lineHeight100;
+}
+
+.caption2strong {
+  font-weight: semibold;
+  font-size: size100;
+  list-style: lineHeight100;
+}
+
+.caption1 {
+  font-weight: regular;
+  font-size: size200;
+  list-style: lineHeight200;
+}
+
+.caption1strong {
+  font-weight: semibold;
+  font-size: size200;
+  list-style: lineHeight200;
+}
+
+.body1 {
+  font-weight: regular;
+  font-size: size300;
+  list-style: lineHeight300;
+}
+
+.body1strong {
+  font-weight: semibold;
+  font-size: size300;
+  list-style: lineHeight300;
+}
+
+.body2 {
+  font-weight: regular;
+  font-size: size400;
+  list-style: lineHeight400;
+}
+
+.body2strong {
+  font-weight: semibold;
+  font-size: size400;
+  list-style: lineHeight400;
+}
+
+.subtitle1 {
+  font-weight: semibold;
+  font-size: size500;
+  list-style: lineHeight500;
+}
+
+.title3 {
+  font-weight: semibold;
+  font-size: size600;
+  list-style: lineHeight600;
+}
+
+.title2 {
+  font-weight: semibold;
+  font-size: size700;
+  list-style: lineHeight700;
+}
+
+.title1 {
+  font-weight: semibold;
+  font-size: size800;
+  list-style: lineHeight800;
+}
+
+.largetitle {
+  font-weight: semibold;
+  font-size: size900;
+  list-style: lineHeight900;
+}


### PR DESCRIPTION
## 구현내용
- 디자인 토큰을 module css의 value 기능을 활용해 추가했습니다.
- variant 정의를 디자인 토큰을 활용해 구현했습니다.

## 피그마 정의
https://www.figma.com/file/PwIfcfR5WgA0dOxlQImoiC/ThanksBucket?type=design&node-id=1-9235&mode=design&t=pE1eksWWb1KiEueX-4
<img width="424" alt="image" src="https://github.com/moim2024/moim-design-system/assets/41099712/72b7da34-6d4d-4147-acd8-76ca46c834ac">

## 구현한 스토리북
<img width="1058" alt="image" src="https://github.com/moim2024/moim-design-system/assets/41099712/3ad7b230-9d6b-4baf-b776-ec541aab1743">
