### PR TITLE
[#12] feat: Chip 구현

### DIFF
--- a/lib/components/Chip/Chip.stories.tsx
+++ b/lib/components/Chip/Chip.stories.tsx
@@ -11,14 +11,14 @@ export default meta
 
 export const Contain: StoryObj<typeof meta> = {
   args: {
-    children: 'Text',
+    text: 'Text',
     onDelete: undefined,
   },
 }
 
 export const OutlineGray: StoryObj<typeof meta> = {
   args: {
-    children: 'Text',
+    text: 'Text',
     variant: 'outline',
     onDelete: undefined,
   },
@@ -26,7 +26,7 @@ export const OutlineGray: StoryObj<typeof meta> = {
 
 export const OutlineBlack: StoryObj<typeof meta> = {
   args: {
-    children: 'Text',
+    text: 'Text',
     variant: 'outline',
     colorScheme: 'black',
     onDelete: undefined,
@@ -42,9 +42,7 @@ export const Icon: StoryFn<typeof meta> = () => {
   }
   return (
     <>
-      <Chip onClick={handleClick} onDelete={handleDelete}>
-        Text
-      </Chip>
+      <Chip text="text" onClick={handleClick} onDelete={handleDelete} />
     </>
   )
 }

--- a/lib/components/Chip/Chip.stories.tsx
+++ b/lib/components/Chip/Chip.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryFn, StoryObj } from '@storybook/react'
+import Chip from '.'
+
+const meta = {
+  title: 'Component/Chip',
+  component: Chip,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Chip>
+
+export default meta
+
+export const Contain: StoryObj<typeof meta> = {
+  args: {
+    children: 'Text',
+    onDelete: undefined,
+  },
+}
+
+export const OutlineGray: StoryObj<typeof meta> = {
+  args: {
+    children: 'Text',
+    variant: 'outline',
+    onDelete: undefined,
+  },
+}
+
+export const OutlineBlack: StoryObj<typeof meta> = {
+  args: {
+    children: 'Text',
+    variant: 'outline',
+    colorScheme: 'black',
+    onDelete: undefined,
+  },
+}
+
+export const Icon: StoryFn<typeof meta> = () => {
+  const handleClick = () => {
+    console.log('click chip')
+  }
+  const handleDelete = () => {
+    console.log('click delete icon')
+  }
+  return (
+    <>
+      <Chip onClick={handleClick} onDelete={handleDelete}>
+        Text
+      </Chip>
+    </>
+  )
+}

--- a/lib/components/Chip/index.tsx
+++ b/lib/components/Chip/index.tsx
@@ -1,0 +1,43 @@
+import styles from './styles.module.css'
+import { CloseCircle } from '../../icons'
+
+export interface ChipProps {
+  children: React.ReactNode
+  variant?: 'contain' | 'outline'
+  colorScheme?: 'gray-300' | 'black'
+  onClick?: (e?: React.MouseEvent) => void
+  onDelete?: (e?: React.MouseEvent) => void | undefined
+}
+
+function Chip({
+  children,
+  variant = 'contain',
+  colorScheme = 'gray-300',
+  onClick,
+  onDelete
+}: ChipProps) {
+  const handleDeleteIconClick = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (onDelete) {
+      onDelete(e)
+    }
+  }
+
+  let deleteIcon = null
+  if (onDelete) {
+    deleteIcon = <CloseCircle onClick={handleDeleteIconClick} />
+  }
+  return (
+    <div
+      className={`${styles.chip} ${styles[variant]} ${styles[colorScheme]} ${
+        onDelete && styles.icon
+      }`}
+      onClick={onClick}
+    >
+      {children}
+      {deleteIcon}
+    </div>
+  )
+}
+
+export default Chip

--- a/lib/components/Chip/index.tsx
+++ b/lib/components/Chip/index.tsx
@@ -1,8 +1,12 @@
-import styles from './styles.module.css'
+import classNames from 'classnames/bind'
+import styles from './styles.module.scss'
+import Typography from '../Typography'
 import { CloseCircle } from '../../icons'
 
+const cx = classNames.bind(styles)
+
 export interface ChipProps {
-  children: React.ReactNode
+  text: string
   variant?: 'contain' | 'outline'
   colorScheme?: 'gray-300' | 'black'
   onClick?: (e?: React.MouseEvent) => void
@@ -10,33 +14,27 @@ export interface ChipProps {
 }
 
 function Chip({
-  children,
+  text,
   variant = 'contain',
   colorScheme = 'gray-300',
   onClick,
-  onDelete
+  onDelete,
 }: ChipProps) {
   const handleDeleteIconClick = (e: React.MouseEvent) => {
     e.stopPropagation()
     if (onDelete) {
-      onDelete(e)
+      onDelete()
     }
   }
 
-  let deleteIcon = null
-  if (onDelete) {
-    deleteIcon = <CloseCircle onClick={handleDeleteIconClick} />
-  }
   return (
-    <div
-      className={`${styles.chip} ${styles[variant]} ${styles[colorScheme]} ${
-        onDelete && styles.icon
-      }`}
+    <button
+      className={cx(variant, colorScheme, { icon: onDelete })}
       onClick={onClick}
     >
-      {children}
-      {deleteIcon}
-    </div>
+      <Typography text={text} variant={'body1strong'} />
+      {onDelete && <CloseCircle onClick={handleDeleteIconClick} />}
+    </button>
   )
 }
 

--- a/lib/components/Chip/styles.module.css
+++ b/lib/components/Chip/styles.module.css
@@ -1,0 +1,35 @@
+@import '../../global.css';
+
+.chip {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+  min-width: 54px;
+  height: 34px;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 600;
+  border-radius: 29px;
+  padding: 6px 12px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.contain {
+  background-color: var(--gray-300);
+}
+
+.outline.gray-300 {
+  border: 1px solid var(--gray-300);
+}
+
+.outline.black {
+  background-color: var(--gray-200);
+  border: 1px solid var(--black);
+}
+
+.icon {
+  min-width: 68px;
+  padding: 6px 6px 6px 12px;
+}

--- a/lib/components/Chip/styles.module.scss
+++ b/lib/components/Chip/styles.module.scss
@@ -1,15 +1,9 @@
-@import '../../global.css';
-
-.chip {
+%chip-base {
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  gap: 4px;
   min-width: 54px;
   height: 34px;
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 600;
   border-radius: 29px;
   padding: 6px 12px;
   cursor: pointer;
@@ -17,7 +11,13 @@
 }
 
 .contain {
+  @extend %chip-base;
+
   background-color: var(--gray-300);
+}
+
+.outline {
+  @extend %chip-base;
 }
 
 .outline.gray-300 {
@@ -30,6 +30,7 @@
 }
 
 .icon {
+  gap: 4px;
   min-width: 68px;
   padding: 6px 6px 6px 12px;
 }


### PR DESCRIPTION
#12

## 구현 내용
- 피그마 정의에 따라 variant, color scheme 등을 구현했습니다.
- onDlete 함수 여부에 따라 icon이 포함되도록 구현했습니다.

## 구현하면서 고민한 것
- chip이 카테고리 선택이나, TO DO LIST 추가된 결과를 나타낼 때 사용되어 처음에 div로 구현한 것을 button으로 수정했습니다.
- #18에서 언급한 Icon wrapper의 필요성

## 피그마 정의
https://www.figma.com/file/PwIfcfR5WgA0dOxlQImoiC/ThanksBucket?type=design&node-id=54-303&mode=design&t=XOwWRO7iiYc0K1m3-0
![image](https://github.com/moim2024/moim-design-system/assets/77879633/b3e4b3a7-9b64-405c-b644-97b6dd256d9f)

## 스토리북
![image](https://github.com/moim2024/moim-design-system/assets/77879633/1b934894-c5ee-4a07-a212-702cbc823155)
